### PR TITLE
feat: add a size threshold for inlining assets

### DIFF
--- a/src/fixtures/css-ext.result.html
+++ b/src/fixtures/css-ext.result.html
@@ -1,1 +1,18 @@
-<!DOCTYPE html><html><head> <meta charset="utf-8"> <title>External script + css</title> <style>p{ font-size:10px;background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;}p:before{ content:'<';color:blue;}</style> <script>console.log('Hello world');</script> <script>function doit(window) { var foo = 'remy'; var bar = window.bar = 'sharp'; return foo + bar.split('').reverse().join(''); } console.log(doit(window)); </script> </head> <body> </body></html>
+<!DOCTYPE html><html><head>
+ <meta charset="utf-8">
+ <title>External script + css</title>
+ <style>p{ font-size:10px;background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;}p:before{ content:'<';color:blue;}</style>
+ <script>console.log('Hello world');</script>
+ <script>function doit(window) {
+ var foo = 'remy';
+ var bar = window.bar = 'sharp';
+ return foo + bar.split('').reverse().join('');
+}
+
+console.log(doit(window));
+</script>
+</head>
+<body>
+
+
+</body></html>

--- a/src/fixtures/css-import.result.html
+++ b/src/fixtures/css-import.result.html
@@ -1,1 +1,10 @@
-<!DOCTYPE html><html><head> <meta charset="utf-8"> <title>inline style</title> <style> p{ font-size:10px;background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;}p:before{ content:'<';color:blue;}p{ font-size:10px;background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;}p:before{ content:'<';color:blue;}p{ font-size:10px;background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;}p:before{ content:'<';color:blue;}@media screen and orientation:landscape{p{ font-size:10px;background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;}p:before{ content:'<';color:blue;}}p{ font-size:10px;background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;}p:before{ content:'<';color:blue;}</style> </head> <body> </body></html>
+<!DOCTYPE html><html><head>
+ <meta charset="utf-8">
+ <title>inline style</title>
+ <style> p{ font-size:10px;background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;}p:before{ content:'<';color:blue;}p{ font-size:10px;background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;}p:before{ content:'<';color:blue;}p{ font-size:10px;background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;}p:before{ content:'<';color:blue;}@media screen and orientation:landscape{p{ font-size:10px;background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;}p:before{ content:'<';color:blue;}}p{ font-size:10px;background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;}p:before{ content:'<';color:blue;}</style>
+</head>
+<body>
+
+
+
+</body></html>

--- a/src/fixtures/favicon.result.html
+++ b/src/fixtures/favicon.result.html
@@ -1,1 +1,10 @@
-<!DOCTYPE html><html><head> <meta charset="utf-8"> <title>inline favicon</title> <link href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/TQBcNTh/AAAACklEQVR4nGNiAAAABgADNjd8qAAAAABJRU5ErkJggg==" rel="icon" type="image/png"> <link href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/TQBcNTh/AAAACklEQVR4nGNiAAAABgADNjd8qAAAAABJRU5ErkJggg==" rel="shortcut icon" type="image/png"> </head> <body> </body></html>
+<!DOCTYPE html><html><head>
+ <meta charset="utf-8">
+ <title>inline favicon</title>
+ <link href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/TQBcNTh/AAAACklEQVR4nGNiAAAABgADNjd8qAAAAABJRU5ErkJggg==" rel="icon" type="image/png">
+ <link href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABAQMAAAAl21bKAAAAA1BMVEX/TQBcNTh/AAAACklEQVR4nGNiAAAABgADNjd8qAAAAABJRU5ErkJggg==" rel="shortcut icon" type="image/png">
+</head>
+<body>
+
+
+</body></html>

--- a/src/fixtures/get-error.result.html
+++ b/src/fixtures/get-error.result.html
@@ -1,1 +1,11 @@
-<!DOCTYPE html><html><head> <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport"> <meta charset="UTF-8"> <title>App</title> <style></style> <script></script> </head> <body> </body></html>
+<!DOCTYPE html><html><head>
+ <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
+ <meta charset="UTF-8">
+ <title>App</title>
+ <style></style>
+ <script></script>
+</head>
+<body>
+
+
+</body></html>

--- a/src/fixtures/image-css.result.html
+++ b/src/fixtures/image-css.result.html
@@ -1,1 +1,9 @@
-<!DOCTYPE html><html><head> <meta charset="utf-8"> <title>css image</title> <style> body{ background:black;}#image{ background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;height:400px;width:400px;}#image{ background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;}p:before{ content:'<';color:blue;}</style> </head> <body> <div id="image"></div> </body></html>
+<!DOCTYPE html><html><head>
+ <meta charset="utf-8">
+ <title>css image</title>
+ <style> body{ background:black;}#image{ background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;height:400px;width:400px;}#image{ background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;}p:before{ content:'<';color:blue;}</style>
+</head>
+<body>
+<div id="image"></div>
+
+</body></html>

--- a/src/fixtures/image-data.result.html
+++ b/src/fixtures/image-data.result.html
@@ -1,1 +1,8 @@
-<!DOCTYPE html><html><head> <meta charset="utf-8"> <title>inline data image</title> </head> <body> <img src="data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs="> </body></html>
+<!DOCTYPE html><html><head>
+ <meta charset="utf-8">
+ <title>inline data image</title>
+</head>
+<body>
+<img src="data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=">
+
+</body></html>

--- a/src/fixtures/image-ext.result.html
+++ b/src/fixtures/image-ext.result.html
@@ -1,1 +1,8 @@
-<!DOCTYPE html><html><head> <meta charset="utf-8"> <title>External image (or local but already resolved source URL)</title> </head> <body> <img src="data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs="> </body></html>
+<!DOCTYPE html><html><head>
+ <meta charset="utf-8">
+ <title>External image (or local but already resolved source URL)</title>
+</head>
+<body>
+ <img src="data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=">
+
+</body></html>

--- a/src/fixtures/image-inline-special-chars.result.html
+++ b/src/fixtures/image-inline-special-chars.result.html
@@ -1,1 +1,9 @@
-<!DOCTYPE html><html><head> <meta charset="utf-8"> <title>inline image with special characters</title> </head> <body> <img src="data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs="> </body></html>
+<!DOCTYPE html><html><head>
+ <meta charset="utf-8">
+ <title>inline image with special characters</title>
+</head>
+<body>
+<img src="data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=">
+
+
+</body></html>

--- a/src/fixtures/image-inline.result.html
+++ b/src/fixtures/image-inline.result.html
@@ -1,1 +1,8 @@
-<!DOCTYPE html><html><head> <meta charset="utf-8"> <title>inline image</title> </head> <body> <img src="data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs="> </body></html>
+<!DOCTYPE html><html><head>
+ <meta charset="utf-8">
+ <title>inline image</title>
+</head>
+<body>
+<img src="data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=">
+
+</body></html>

--- a/src/fixtures/image-style-attr.result.html
+++ b/src/fixtures/image-style-attr.result.html
@@ -1,1 +1,12 @@
-<!DOCTYPE html><html><head> <meta charset="utf-8"> <title>css image in style attr</title> </head> <body> <div style="background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;"></div> <div style="background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;"></div> <div style="background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;"></div> <div style="background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;"></div> </body></html>
+<!DOCTYPE html><html><head>
+ <meta charset="utf-8">
+ <title>css image in style attr</title>
+</head>
+<body>
+<div style="background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;"></div>
+<div style="background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;"></div>
+<div style="background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;"></div>
+<div style="background:url('data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=') repeat;"></div>
+
+
+</body></html>

--- a/src/fixtures/image-url.result.html
+++ b/src/fixtures/image-url.result.html
@@ -1,1 +1,8 @@
-<!DOCTYPE html><html><head> <meta charset="utf-8"> <title>inline image</title> </head> <body> <img src="data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs="> </body></html>
+<!DOCTYPE html><html><head>
+ <meta charset="utf-8">
+ <title>inline image</title>
+</head>
+<body>
+<img src="data:image/gif;base64,R0lGODlhAQABAIABAP///wAAACwAAAAAAQABAAACAkQBADs=">
+
+</body></html>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,11 +228,6 @@ mod tests {
   use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
   use tiny_http::{Header, Response, Server, StatusCode};
 
-  #[cfg(windows)]
-  const LINE_ENDING: &str = "\r\n";
-  #[cfg(not(windows))]
-  const LINE_ENDING: &str = "\n";
-
   #[test]
   fn match_fixture() {
     env_logger::init();
@@ -274,8 +269,7 @@ mod tests {
       }
 
       let output = super::inline_file(&path, Default::default())
-        .unwrap()
-        .replace("\n", LINE_ENDING);
+        .unwrap();
 
       let expected = read_to_string(
         path
@@ -285,7 +279,9 @@ mod tests {
       )
       .unwrap();
 
-      if output.replace("\n", " ") != expected.replace("\n", " ") {
+      let not_equal = output.chars().filter(|c| *c as u32 != 13).zip(expected.chars().filter(|c| *c as u32 != 13)).any(|(a, b)| a != b);
+
+      if not_equal {
         _print_diff(output, expected);
         panic!("test case `{}` failed", file_name.replace(".src.html", ""));
       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,7 +285,7 @@ mod tests {
       )
       .unwrap();
 
-      if output != expected {
+      if output.replace("\n", " ") != expected.replace("\n", " ") {
         _print_diff(output, expected);
         panic!("test case `{}` failed", file_name.replace(".src.html", ""));
       }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,7 @@ use std::{
   path::{Path, PathBuf},
 };
 
-use html5ever::QualName;
 use kuchiki::traits::TendrilSink;
-use kuchiki::NodeRef;
 use once_cell::sync::Lazy;
 use url::Url;
 
@@ -217,34 +215,6 @@ pub fn inline_html_string<P: AsRef<Path>>(
   js_css::inline_script_link(&mut cache, &config, &root_path, &document)?;
 
   let html = if config.remove_new_lines {
-    for target in document.select("pre, textarea, script").unwrap() {
-      let node = target.as_node();
-      let element = node.as_element().unwrap();
-
-      if element.name.local.to_string().as_str() == "script" {
-        let attrs = element.attributes.borrow();
-        if attrs.get("defer").is_some()
-          || attrs.get("src").is_some()
-          || attrs.get("type").unwrap_or("text/javascript") != "text/javascript"
-        {
-          continue;
-        }
-      }
-
-      let replacement_node = NodeRef::new_element(
-        QualName::new(None, ns!(html), element.name.local.to_string().into()),
-        None,
-      );
-      replacement_node.append(NodeRef::new_text(
-        node
-          .text_contents()
-          .replace("\n", EOL_REPLACEMENT)
-          .replace(" ", SPACE_REPLACEMENT),
-      ));
-
-      node.insert_after(replacement_node);
-      node.detach();
-    }
     let html = document.to_string();
     html
       .replace("\n", " ")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -268,8 +268,7 @@ mod tests {
         continue;
       }
 
-      let output = super::inline_file(&path, Default::default())
-        .unwrap();
+      let output = super::inline_file(&path, Default::default()).unwrap();
 
       let expected = read_to_string(
         path
@@ -279,7 +278,11 @@ mod tests {
       )
       .unwrap();
 
-      let not_equal = output.chars().filter(|c| *c as u32 != 13).zip(expected.chars().filter(|c| *c as u32 != 13)).any(|(a, b)| a != b);
+      let not_equal = output
+        .chars()
+        .filter(|c| *c as u32 != 13)
+        .zip(expected.chars().filter(|c| *c as u32 != 13))
+        .any(|(a, b)| a != b);
 
       if not_equal {
         _print_diff(output, expected);


### PR DESCRIPTION
Large assets, when inlined, will cause extremely long load times as the data has to be passed through a data URL to the webview in Tauri, causing https://github.com/tauri-apps/tauri/issues/902. This PR adds a configurable size maximum (defaults to 5kb) for inlining assets.